### PR TITLE
Get user scope

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -58,9 +58,11 @@ Inside of config.json, paste the following sample:
     "client_id": "",
     "team_id": "",
     "redirect_uri": "",
-    "key_id": ""
+    "key_id": "",
+    "scope": ""
 }
 ```
+The ```scope```field is to set what information we want to gather from the user. We can set ```email``` and/or ```name```. This information is still not provided by Apple because this feature is still in Beta - but if you provide it the first time, when Apple finally releases it, your application will already have this permission provided. Otherwise the user has to revoke permissions to your application and log in again to be prompted for the new information request.
 
 The ```client_id``` is actually called the "Service ID" that you will create in the 'Identifiers' section
 

--- a/src/apple-auth.js
+++ b/src/apple-auth.js
@@ -20,7 +20,7 @@ class AppleAuth {
      *  found on top right corner of the developers page
      * @param {string} config.redirect_uri – The OAuth Redirect URI
      * @param {string} config.key_id – The identifier for the private key on the Apple
-     * @param {string} scope - the scope of information you want to get from the user (user name and email)
+     * @param {string} config.scope - the scope of information you want to get from the user (user name and email)
      *  Developer Account page
      * @param {string} privateKeyLocation - Location to the private key
      */

--- a/src/apple-auth.js
+++ b/src/apple-auth.js
@@ -20,6 +20,7 @@ class AppleAuth {
      *  found on top right corner of the developers page
      * @param {string} config.redirect_uri – The OAuth Redirect URI
      * @param {string} config.key_id – The identifier for the private key on the Apple
+     * @param {string} scope - the scope of information you want to get from the user (user name and email)
      *  Developer Account page
      * @param {string} privateKeyLocation - Location to the private key
      */
@@ -52,6 +53,7 @@ class AppleAuth {
                     + "&client_id=" + this._config.client_id
                     + "&redirect_uri=" + this._config.redirect_uri
                     + "&state=" + this._state
+                    + "&scope=" + this._config.scope
         return url;
     }
 


### PR DESCRIPTION
This feature allows you to set what information you want to request from the user when signing in. I've updated the "setup.md" file explaining this functionality and its limitations - seen as it's currently in Beta, Apple does not provide this user information just yet, but you can configure your app to request it so when it's finally released/allowed, your app already has the necessary permissions to gather this information.