### PR TITLE
Return after rejects to not have unnecessary processing

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -51,6 +51,7 @@ class AppleClientSecret {
                 }, (err, token) => {
                     if (err) {
                         reject("AppleAuth Error – Error occurred while signing: " + err);
+                        return;
                     }
                     resolve(token);
                 });
@@ -69,6 +70,7 @@ class AppleClientSecret {
                 fs.readFile(this._privateKeyLocation, (err, privateKey) => {
                     if (err) {
                         reject("AppleAuth Error - Couldn't read your Private Key file: " + err);
+                        return;
                     }
                     let exp = Math.floor(Date.now() / 1000) + ( 86400 * 180 ); // Make it expire within 6 months
                     this._generateToken(


### PR DESCRIPTION
If you don't return after the rejections, the code below will still run but nothing can be returned in subsequent reject or resolve calls, so there is no point in continuing.