### PR TITLE
prevent overwriting _privateKey if we already have it

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -90,17 +90,21 @@ class AppleClientSecret {
                         reject(err);
                     });
                 }
-                if (!that._privateKey && that._privateKeyMethod == 'file') {
-                    fs.readFile(that._privateKeyLocation, (err, privateKey) => {
-                        if (err) {
-                            reject("AppleAuth Error - Couldn't read your Private Key file: " + err);
-                            return;
-                        }
-                        that._privateKey = privateKey;
-                        generateToken();
-                    });
+                if (!that._privateKey) {
+                    if (that._privateKeyMethod == 'file') {
+                        fs.readFile(that._privateKeyLocation, (err, privateKey) => {
+                            if (err) {
+                                reject("AppleAuth Error - Couldn't read your Private Key file: " + err);
+                                return;
+                            }
+                            that._privateKey = privateKey;
+                            generateToken();
+                        });
+                    } else {
+                        that._privateKey = that._privateKeyLocation;
+                        process.nextTick(generateToken);
+                    }
                 } else {
-                    that._privateKey = that._privateKeyLocation;
                     process.nextTick(generateToken);
                 }
             }


### PR DESCRIPTION
I have made a mistake and if you try and make a second request it fails because it would overwrite the private key with the location. this fixes that.