### PR TITLE
Typescript Constructor argument fixed. add "privateKeyMethod"

### DIFF
--- a/src/apple-auth.d.ts
+++ b/src/apple-auth.d.ts
@@ -18,7 +18,7 @@ declare module "apple-auth" {
     error: "invalid_request" | "invalid_client" | "invalid_grant" | "unauthorized_client" | "unsupported_grant_type" | "invalid_scope";
   }
   export default class AppleAuth {
-    constructor(config: AppleAuthConfig, privateKeyLocation: string)
+    constructor(config: AppleAuthConfig, privateKeyLocation: string, privateKeyMethod: string)
     loginURL(): string;
     accessToken(code: string): Promise<AppleAuthAccessToken>;
     refreshToken(code: string): Promise<AppleAuthAccessToken>;


### PR DESCRIPTION
Hi, I'm KyoungDuck Kim, I'm node.js developer.

I got an error when I use typescript.

So I changed the constructure arguments.

I add 'privateKeyMethod: string'.

thanks for made this project and please review my pull request.

(I hope there is no error my english... I'm not good at English T_T)