### PR TITLE
Properly encode parameters of loginURL

### DIFF
--- a/src/apple-auth.js
+++ b/src/apple-auth.js
@@ -57,14 +57,14 @@ class AppleAuth {
 
     loginURL() {
         this._state = crypto.randomBytes(5).toString('hex');
-        const url = "https://appleid.apple.com/auth/authorize?"
-                    + "response_type=code%20id_token"
-                    + "&client_id=" + this._config.client_id
-                    + "&redirect_uri=" + this._config.redirect_uri
-                    + "&state=" + this._state
-                    + "&scope=" + this._config.scope
-	 	    + "&response_mode=form_post"
-        return url;
+        return "https://appleid.apple.com/auth/authorize?" + qs.stringify({
+            response_type: "code id_token",
+            client_id: this._config.client_id,
+            redirect_uri: this._config.redirect_uri,
+            state: this._state,
+            scope: this._config.scope,
+            response_mode: "form_post"
+        });
     }
 
     /**


### PR DESCRIPTION
We weren't escaping query parameters before, leading to issues with certain redirect URLs. URL encoded redirect URLs can't be provided by the API consumer because we would later encode it again before sending it to Apple.