### PR TITLE
AccessToken error response data

### DIFF
--- a/src/apple-auth.js
+++ b/src/apple-auth.js
@@ -93,7 +93,11 @@ class AppleAuth {
                     }).then((response) => {
                         resolve(response.data);
                     }).catch((response) => {
-                        reject("AppleAuth Error - An error occurred while getting response from Apple's servers: " + response);
+                        const responseData = response.response?.data
+                        reject(
+                            `AppleAuth Error - An error occurred while getting response from Apple's servers: 
+                            ${response}${responseData ? (" | " + responseData) : ""}`
+                        );
                     });
                 }).catch((err) => {
                     reject(err);


### PR DESCRIPTION
Fixes: https://github.com/ananay/apple-auth/issues/31

Adding more verbose error message for `accessToken` call.
Apple provides the reason why the request was rejected eg.:
```
 {
  error: 'invalid_grant',
  error_description: 'The code has already been used.'
}
```